### PR TITLE
Change default `n_jobs` to 5

### DIFF
--- a/dropkick/api.py
+++ b/dropkick/api.py
@@ -426,7 +426,7 @@ def dropkick(
     directions=["above"],
     alphas=[0.1],
     max_iter=2000,
-    n_jobs=2,
+    n_jobs=5,
     seed=18,
     verbose=True,
 ):


### PR DESCRIPTION
The tutorial ipynb file mentions "Since the default is 5-fold cross-validation, we'll use 5 cores to quickly train **dropkick**" within section 2; however, the default value for `n_jobs` within the function definition is 2.